### PR TITLE
2021.09 state_class

### DIFF
--- a/sma-em/config.json
+++ b/sma-em/config.json
@@ -28,7 +28,7 @@
     "THRESHOLD": 80,
     "RECONNECT_INTERVAL": 86400,
     "DEBUG": 0,
-    "AUTODISCOVER_CONFIG": [{"key": "state_class", "value": "measurement"}]
+    "AUTODISCOVER_CONFIG": [{"key": "state_class", "value": "total_increasing"}]
   },
   "schema": {
     "MQTT_HOST": "str",

--- a/sma-em/config.json
+++ b/sma-em/config.json
@@ -2,7 +2,7 @@
   "name": "SMA Energy Meter",
   "slug": "sma-em",
   "description": "Add-on for the SMA Energy meter",
-  "version": "2021.8.1",
+  "version": "2021.9.1",
   "startup": "services",
   "boot": "auto",
   "url": "https://github.com/kellerza/hassio-sma-em",


### PR DESCRIPTION
`state_class` can be set to `total_increasing` from HASS 2021.09. Then you do not need to customize the `last_reset` attribute any longer