### PR TITLE
Enable meter statistics by setting last_reset topic

### DIFF
--- a/sma-em-dev/sensors.py
+++ b/sma-em-dev/sensors.py
@@ -149,6 +149,8 @@ async def hass_discover_sensor(*, sma_id: str, sensor: SWSensor):
             "unit_of_meas": sensor.unit,
             "uniq_id": f"{sma_id}_{sensor.id}",
             "state_class": "measurement",
+            "last_reset_topic": f"{SMA_EM_TOPIC}/{sma_id}/{sensor.id}",
+            "last_reset_value_template": "1970-01-01T00:00:00+00:00",
             "dev": {
                 "ids": [f"sma_em_{sma_id}"],
                 "name": "SMA Energy Meter",


### PR DESCRIPTION
Following docu from HA core: 

"The MQTT topic subscribed to receive timestamps for when an accumulating
sensor such as an energy meter was reset. If the sensor never resets,
set last_reset_topic to same as state_topic and set the
last_reset_value_template to a constant valid timstamp, for example UNIX
epoch 0: 1970-01-01T00:00:00+00:00."