### PR TITLE
Make IP bind configurable

### DIFF
--- a/sma-em/config.ini
+++ b/sma-em/config.ini
@@ -4,7 +4,7 @@ features=mqtt
 
 [DAEMON]
 pidfile=/run/smaemd.pid
-ipbind=0.0.0.0
+ipbind=$IPBIND
 mcastgrp=239.12.255.254
 mcastport=9522
 statusdir=

--- a/sma-em/config.yaml
+++ b/sma-em/config.yaml
@@ -19,6 +19,7 @@ options:
     MQTT_PORT: 1883
     MQTT_USERNAME: hass
     MQTT_PASSWORD: my_very_secure_password
+    IPBIND: ""
     SMA_SERIALS: []
     FIELDS:
         - pconsume
@@ -33,6 +34,7 @@ schema:
     MQTT_PORT: port
     MQTT_USERNAME: str
     MQTT_PASSWORD: password
+    IPBIND: str
     SMA_SERIALS:
         - str
     FIELDS:

--- a/sma-em/run.py
+++ b/sma-em/run.py
@@ -11,7 +11,6 @@ from speedwiredecoder import decode_speedwire
 
 MCAST_GRP = "239.12.255.254"
 MCAST_PORT = 9522
-IPBIND = "0.0.0.0"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ def connect_socket():
     try:
         # mreq = struct.pack("4s4s", group, socket.INADDR_ANY)
         mreq = struct.pack(
-            "4s4s", socket.inet_aton(MCAST_GRP), socket.inet_aton(IPBIND)
+            "4s4s", socket.inet_aton(MCAST_GRP), socket.inet_aton(sensors.OPTIONS.get("IPBIND", "0.0.0.0"))
         )
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
     except BaseException:

--- a/sma-em/sensors.py
+++ b/sma-em/sensors.py
@@ -46,6 +46,7 @@ MQTT_HOST = "MQTT_HOST"
 MQTT_PORT = "MQTT_PORT"
 MQTT_USERNAME = "MQTT_USERNAME"
 MQTT_PASSWORD = "MQTT_PASSWORD"
+IPBIND = "IPBIND"
 SERIALS = "SMA_SERIALS"
 FIELDS = "FIELDS"
 THRESHOLD = "THRESHOLD"
@@ -204,6 +205,7 @@ def startup():
             MQTT_PASSWORD: sys.argv[1],
             MQTT_PORT: 1883,
             MQTT_USERNAME: "hass",
+            IP_BIND: "",
             SERIALS: [],
             FIELDS: [
                 "pconsume",


### PR DESCRIPTION
Some Home Assistant (OS) installations may have more than one interface assigned to them, e.g., when IoT devices are located in their own subnet (e.g., to prevent the smart meter from establishing a connection with some cloud services).

During the multicast listener's setup, one needs to explicitly specify the local address in that case. This change allows users with such a setup to use this addon as well.

The commit should be backwards compatible as far as I can see, but I don't consider myself an expert on Home Assistant. Feedback welcome. The value should be optional, i.e., an empty string is the default value. There might be a more elegant solution to this.

P.S.: This is basically the same change I had to use with the original SMA-EM project to receive any data from the meter.