### PR TITLE
correct Device class for Ampere and Voltage

### DIFF
--- a/sma-em/sensors.py
+++ b/sma-em/sensors.py
@@ -143,7 +143,7 @@ def hass_device_class(*, unit: str):
         "kVAh": "energy",
     }.get(
         unit, None
-    )  # kwh, kVa,
+    ) # unknown device_class
 
 
 async def hass_discover_sensor(*, sma_id: str, sensor: SWSensor):

--- a/sma-em/sensors.py
+++ b/sma-em/sensors.py
@@ -127,17 +127,22 @@ async def process_emparts(emparts: dict):
         await mqtt_publish(f"{SMA_EM_TOPIC}/{emparts['serial']}/{sen.id}", sen.value)
 
 
-# device_calss:current/energy/power
+# device_calss:current/energy/power/voltage
 # unit_of_measurement
 def hass_device_class(*, unit: str):
     return {
         "W": "power",
         "kW": "power",
+        "VA": "power",
         "kVA": "power",
         "V": "voltage",
-        "Hz": None,
+        "A": "current",
+        "Wh": "energy",
+        "kWh": "energy",
+        "VAh": "energy",
+        "kVAh": "energy",
     }.get(
-        unit, "energy"
+        unit, None
     )  # kwh, kVa,
 
 


### PR DESCRIPTION
This are the logs in homeassistant, this pull request solves warning for wrong device_class 

2024-02-13 19:08:51.558 WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.sma_energy_meter_cosphi (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using native unit of measurement **'°'** which is not a valid unit for the device class (**'energy'**) it is using; expected one of **['MWh', 'Wh', 'GJ', 'kWh', 'MJ'];**

2024-02-13 19:08:51.565 WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.sma_energy_meter_i1 (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using native unit of measurement **'A'** which is not a valid unit for the device class (**'energy'**) it is using; expected one of **['MWh', 'Wh', 'GJ', 'kWh', 'MJ'];**