### PR TITLE
Adding Multicast Group as an Option

### DIFF
--- a/sma-em-dev/CHANGELOG.md
+++ b/sma-em-dev/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## **2024.5.10** - 2024-05-10
+- Added Multicast Adress as an Option Field
+
+
 ## **2023.5.18** - 2023-05-18
 - Removed round - Issue #27
 

--- a/sma-em-dev/DOCS.md
+++ b/sma-em-dev/DOCS.md
@@ -2,6 +2,11 @@
 
 ## Parameters
 
+- `MCASTGRP`
+
+  Multicast address that is configured in the SMA Energy Meter. Default value is 239.12.255.254.
+
+
 - `MQTT_*`
 
   You will need a working MQTT sevrer since all values will be sent via MQTT.

--- a/sma-em-dev/config.yaml
+++ b/sma-em-dev/config.yaml
@@ -29,7 +29,7 @@ options:
     RECONNECT_INTERVAL: 86400
     DEBUG: 0
 schema:
-    MCASTGRP: str
+    MCASTGRP: str?
     MQTT_HOST: str
     MQTT_PORT: port
     MQTT_USERNAME: str

--- a/sma-em-dev/config.yaml
+++ b/sma-em-dev/config.yaml
@@ -15,6 +15,7 @@ ports: {}
 ports_description: {}
 host_network: true
 options:
+    MCASTGRP: 239.12.255.254 
     MQTT_HOST: core-mosquitto
     MQTT_PORT: 1883
     MQTT_USERNAME: hass
@@ -28,6 +29,7 @@ options:
     RECONNECT_INTERVAL: 86400
     DEBUG: 0
 schema:
+    MCASTGRP: str
     MQTT_HOST: str
     MQTT_PORT: port
     MQTT_USERNAME: str

--- a/sma-em-dev/config.yaml
+++ b/sma-em-dev/config.yaml
@@ -1,7 +1,7 @@
 name: SMA Energy Meter *developer version*
 slug: sma-em-dev
 description: Add-on for the SMA Energy meter
-version: 2023.5.18
+version: 2024.5.10
 startup: services
 boot: auto
 url: 'https://github.com/kellerza/hassio-sma-em-dev'

--- a/sma-em-dev/options.py
+++ b/sma-em-dev/options.py
@@ -16,6 +16,7 @@ class Options:
     """HASS Addon Options."""
 
     # pylint: disable=too-few-public-methods
+    mcastgrp: str = "239.12.255.254"
     mqtt_host: str = ""
     mqtt_port: int = 0
     mqtt_username: str = ""

--- a/sma-em-dev/options.py
+++ b/sma-em-dev/options.py
@@ -16,7 +16,7 @@ class Options:
     """HASS Addon Options."""
 
     # pylint: disable=too-few-public-methods
-    mcastgrp: str = ""
+    mcastgrp: str = "239.12.255.254"
     mqtt_host: str = ""
     mqtt_port: int = 0
     mqtt_username: str = ""

--- a/sma-em-dev/options.py
+++ b/sma-em-dev/options.py
@@ -16,7 +16,7 @@ class Options:
     """HASS Addon Options."""
 
     # pylint: disable=too-few-public-methods
-    mcastgrp: str = "239.12.255.254"
+    mcastgrp: str = ""
     mqtt_host: str = ""
     mqtt_port: int = 0
     mqtt_username: str = ""

--- a/sma-em-dev/run.py
+++ b/sma-em-dev/run.py
@@ -10,7 +10,6 @@ import sensors
 from options import OPT, init_options
 from speedwiredecoder import decode_speedwire
 
-MCAST_GRP = "239.12.255.254"
 MCAST_PORT = 9522
 IPBIND = "0.0.0.0"
 
@@ -45,7 +44,7 @@ def connect_socket():
     try:
         # mreq = struct.pack("4s4s", group, socket.INADDR_ANY)
         mreq = struct.pack(
-            "4s4s", socket.inet_aton(MCAST_GRP), socket.inet_aton(IPBIND)
+            "4s4s", socket.inet_aton(OPT.mcastgrp), socket.inet_aton(IPBIND)
         )
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
     except BaseException:  # pylint: disable=broad-except


### PR DESCRIPTION
* Adding Multicast group as an Option with default value 239.12.255.254

Due to the fact, that the default Multicast group ist not working correct in my Network as long as the inverter is connected via Speedline, i had to change the Multicast group (239.12.255.254) in my Energy Meter (SMA-EM) to another value (239.12.255.253 which works for me and the SMA Home Manager incl. Sunny Portal)
To make this wonderfull Addon work again i had to made these changes.